### PR TITLE
Fix tiptap code block syntax highlighting

### DIFF
--- a/apps/public/package.json
+++ b/apps/public/package.json
@@ -24,6 +24,7 @@
     "@types/node": "^22.15.29",
     "@vitejs/plugin-react": "^4.3.4",
     "date-fns": "^4.1.0",
+    "highlight.js": "^11.11.1",
     "hono": "catalog:",
     "immer": "^10.1.1",
     "lodash": "^4.17.21",

--- a/apps/public/src/modules/board.tsx
+++ b/apps/public/src/modules/board.tsx
@@ -1,6 +1,7 @@
 import { api } from "@lib/api";
 import { editorContentClassName, generateHtml } from "@mono/editor";
 import { Avatar, Button, Tag, Text } from "@mono/ui";
+import "highlight.js/styles/atom-one-light.min.css";
 import { cn } from "@mono/ui/utils";
 import { createFileRoute } from "@tanstack/react-router";
 import { format } from "date-fns";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       hono:
         specifier: 'catalog:'
         version: 4.8.1


### PR DESCRIPTION
Add `highlight.js` CSS import to the public app to enable syntax highlighting for code blocks.

---
Linear Issue: [SPI-5](https://linear.app/spicy-sauce/issue/SPI-5/code-blocks-are-not-highlighted-in-the-public-app)

<a href="https://cursor.com/background-agent?bcId=bc-5c78ef5e-00e3-47ba-835e-4937ba8695ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c78ef5e-00e3-47ba-835e-4937ba8695ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

