### PR TITLE
Remove filters button from updates page

### DIFF
--- a/apps/web/src/modules/dashboard/pages/updates/pages/list/page.tsx
+++ b/apps/web/src/modules/dashboard/pages/updates/pages/list/page.tsx
@@ -6,7 +6,7 @@ import { useCreateUpdateMutation } from "@modules/dashboard/hooks/use-create-upd
 import { Button, Text } from "@mono/ui";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { ListFilterIcon } from "lucide-react";
+
 import { match, P } from "ts-pattern";
 import { Empty } from "./empty";
 import { List } from "./list";
@@ -43,14 +43,6 @@ function RouteComponent() {
       <Page.Header className="justify-between py-2">
         <Breadcrumbs page="Updates" />
         <div className="flex items-center gap-2">
-          <Button.Root
-            isLoading={createPostMutation.isPending}
-            onClick={handleCreatePost}
-            variant="secondary"
-          >
-            <Button.Icon render={<ListFilterIcon />} />
-            Filters
-          </Button.Root>
           <Button.Root
             isLoading={createPostMutation.isPending}
             onClick={handleCreatePost}

--- a/apps/web/src/modules/dashboard/pages/updates/pages/list/page.tsx
+++ b/apps/web/src/modules/dashboard/pages/updates/pages/list/page.tsx
@@ -42,14 +42,12 @@ function RouteComponent() {
     <Page.Wrapper>
       <Page.Header className="justify-between py-2">
         <Breadcrumbs page="Updates" />
-        <div className="flex items-center gap-2">
-          <Button.Root
-            isLoading={createPostMutation.isPending}
-            onClick={handleCreatePost}
-          >
-            New Draft
-          </Button.Root>
-        </div>
+        <Button.Root
+          isLoading={createPostMutation.isPending}
+          onClick={handleCreatePost}
+        >
+          New Draft
+        </Button.Root>
       </Page.Header>
       <Page.Content className="flex-1 gap-0 p-0">
         <Transition.Root>


### PR DESCRIPTION
Remove the "Filters" button from the Updates page as per Linear issue RLO-6.

---
Linear Issue: [RLO-6](https://linear.app/spicy-sauce/issue/RLO-6/remove-filters-button-from-updates-page)

<a href="https://cursor.com/background-agent?bcId=bc-51dad762-c83b-4549-9827-20b99168ddca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51dad762-c83b-4549-9827-20b99168ddca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

